### PR TITLE
adding ubuntu netplan template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,6 @@ vm_unique_net_interfaces: []
   #   ip6: 200:db9::10
   #   gw6: 200:db9::1
   #   netmask6: 64
+
+#vm_unique_net_nameserver: "192.168.1.2, 192.168.1.3" 
+#vm_unique_net_search: "example.org" 

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -1,0 +1,27 @@
+network:
+  ethernets:
+{% for interface in vm_unique_net_interfaces %}
+    {{ interface.name }}:
+      addresses:
+{% if (interface.ip4 is defined) %}
+        - {{ interface.ip4 }}/{{ interface.netmask4 }}
+{% endif %}
+{% if (interface.ip6 is defined) %}
+        - {{ interface.ip6 }}/{{ interface.netmask6 }}
+{% endif %}
+{% if (interface.ip4 is defined) %}
+      gateway4: {{ interface.gw4 }}
+{% endif %}
+{% if (interface.ip6 is defined) %}
+      gateway6: {{ interface.gw6 }}
+{% endif %}
+{% if (vm_unique_net_nameserver is defined) %}
+      nameservers:
+        addresses: [{{ vm_unique_net_nameserver }}]
+{% if (vm_unique_net_search is defined) %}
+        search: [{{ vm_unique_net_search }}]
+{% endif %}
+{% endif %}
+  version: 2
+
+{% endfor %}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -1,0 +1,25 @@
+network:
+  ethernets:
+{% for interface in vm_unique_net_interfaces %}
+    {{ interface.name }}:
+      addresses:
+{% if (interface.ip4 is defined) %}
+        - {{ interface.ip4 }}/{{ interface.netmask4 }}
+{% endif %}
+{% if (interface.ip6 is defined) %}
+        - {{ interface.ip6 }}/{{ interface.netmask6 }}
+{% endif %}
+{% if (interface.ip4 is defined) %}
+      gateway4: {{ interface.gw4 }}
+{% endif %}
+{% if (interface.ip6 is defined) %}
+      gateway6: {{ interface.gw6 }}
+{% endif %}
+{% if (vm_unique_net_nameserver is defined) %}
+      nameservers:
+        addresses: [{{ vm_unique_net_nameserver }}]
+{% if (vm_unique_net_search is defined) %}
+        search: [{{ vm_unique_net_search }}]
+{% endif %}
+{% endif %}
+  version: 2

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -24,4 +24,4 @@ network:
 {% endif %}
   version: 2
 
-{% end for %}
+{% endfor %}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -23,3 +23,5 @@ network:
 {% endif %}
 {% endif %}
   version: 2
+
+{% end for %}


### PR DESCRIPTION
I'm not sure about this change.

cloning an ubuntu 18 template I found that the network configuration is in `etc / netplan` with yaml format instead of `/ etc / interfaces`, so I created a new template and placed it in my playbook and everything worked fine.

Do you think it would be good to include the template here (only affects ubuntu 18 and higher i think)? if not, I close the pull request.

Cheers