### PR TITLE
ubuntu 18 and higher net template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ vm_unique_ssh_config_path: '' # e.g. '/etc/ssh/sshd_config'
 # Configure the SSH login type allowed for root
 vm_unique_ssh_permit_root_login: prohibit-password  # prohibit-password - no - yes
 
-# Source template and destination configuration file for network interfaces
+# Source template and destination configuration file for network interfaces. Typical example
+# for Debian-based distributions. Look at the "templates" folder for more examples.
 vm_unique_net_config_template: etc/network/interfaces.j2
 vm_unique_net_config_path: /etc/network/interfaces
 # To avoid problems (IP conflicts), this list is empty by default, causing the related task to be skipped

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,6 @@ vm_unique_net_interfaces: []
   #   ip6: 200:db9::10
   #   gw6: 200:db9::1
   #   netmask6: 64
+
+#vm_unique_net_nameserver: "192.168.1.2, 192.168.1.3" 
+#vm_unique_net_search: "example.org" 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,8 @@ vm_unique_ssh_config_path: '' # e.g. '/etc/ssh/sshd_config'
 # Configure the SSH login type allowed for root
 vm_unique_ssh_permit_root_login: prohibit-password  # prohibit-password - no - yes
 
-# Source template and destination configuration file for network interfaces
+# Source template and destination configuration file for network interfaces. Typical example
+# for Debian-based distributions. Look at the "templates" folder for more examples.
 vm_unique_net_config_template: etc/network/interfaces.j2
 vm_unique_net_config_path: /etc/network/interfaces
 # To avoid problems (IP conflicts), this list is empty by default, causing the related task to be skipped
@@ -54,6 +55,6 @@ vm_unique_net_interfaces: []
   #   gw6: 200:db9::1
   #   netmask6: 64
   #   nameservers:
-  #     - '1.1.1.1'  
+  #     - '1.1.1.1'
   #     - '8.8.8.8'
-  
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ vm_unique_net_interfaces: []
   #   ip6: 200:db9::10
   #   gw6: 200:db9::1
   #   netmask6: 64
-
-#vm_unique_net_nameserver: "192.168.1.2, 192.168.1.3" 
-#vm_unique_net_search: "example.org" 
+  #   nameservers:
+  #     - '1.1.1.1'  
+  #     - '8.8.8.8'
+  

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -1,0 +1,27 @@
+network:
+  ethernets:
+{% for interface in vm_unique_net_interfaces %}
+    {{ interface.name }}:
+      addresses:
+{% if (interface.ip4 is defined) %}
+        - {{ interface.ip4 }}/{{ interface.netmask4 }}
+{% endif %}
+{% if (interface.ip6 is defined) %}
+        - {{ interface.ip6 }}/{{ interface.netmask6 }}
+{% endif %}
+{% if (interface.ip4 is defined) %}
+      gateway4: {{ interface.gw4 }}
+{% endif %}
+{% if (interface.ip6 is defined) %}
+      gateway6: {{ interface.gw6 }}
+{% endif %}
+{% if (vm_unique_net_nameserver is defined) %}
+      nameservers:
+        addresses: [{{ vm_unique_net_nameserver }}]
+{% if (vm_unique_net_search is defined) %}
+        search: [{{ vm_unique_net_search }}]
+{% endif %}
+{% endif %}
+  version: 2
+
+{% endfor %}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -9,17 +9,17 @@ network:
 {% if (interface.ip6 is defined) %}
         - {{ interface.ip6 }}/{{ interface.netmask6 }}
 {% endif %}
-{% if (interface.ip4 is defined) %}
+{% if (interface.gw4 is defined) %}
       gateway4: {{ interface.gw4 }}
 {% endif %}
-{% if (interface.ip6 is defined) %}
+{% if (interface.gw6 is defined) %}
       gateway6: {{ interface.gw6 }}
 {% endif %}
-{% if (vm_unique_net_nameserver is defined) %}
+{% if (interface.nameservers is defined) %}
       nameservers:
-        addresses: [{{ vm_unique_net_nameserver }}]
-{% if (vm_unique_net_search is defined) %}
-        search: [{{ vm_unique_net_search }}]
+        addresses: [{{ interface.nameservers | join(',') }}]
+{% if (interface.search is defined) %}
+        search: [{{ interface.search }}]
 {% endif %}
 {% endif %}
   version: 2


### PR DESCRIPTION
I'm not sure about this change.

cloning an ubuntu 18 template I found that the network configuration is in `etc / netplan` with yaml format instead of  `/ etc / interfaces`, so I created a new template and placed it in my playbook and everything worked fine.

Do you think it would be good to include the template here (only affects ubuntu 18 and higher i think)? if not, I will close the pull request.

Cheers